### PR TITLE
Add caselaw fetch and log parsing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # CIVIL-RIGHTS-LAWSUIT-FED
+
+This repository contains documents related to an ongoing civil rights case. The scripts in the `scripts/` directory help build a local legal research assistant using a 7B language model.
+
+## Preparing a Dataset
+Extract text from the PDFs in this repository and save them as a JSONL file:
+
+```bash
+python scripts/build_dataset.py . dataset.jsonl
+```
+
+## Training a 7B Model
+Fine-tune a 7B base model (for example `mistralai/Mistral-7B-v0.1`) on the dataset:
+
+```bash
+python scripts/train_llm.py dataset.jsonl --output_dir my_model
+```
+
+This uses the HuggingFace `transformers` library and expects a GPU such as an RTX 3060.
+
+## Building a Retrieval System
+Create a simple FAISS index for retrieval-augmented generation:
+
+```bash
+python scripts/setup_rag.py dataset.jsonl --persist_dir index
+```
+
+You can then load the index with your fine-tuned model to answer questions about the case documents.
+
+## Fetching Colorado Caselaw
+Use the CourtListener API to download opinions for Colorado courts and store them as JSONL:
+
+```bash
+python scripts/fetch_caselaw.py opinions.jsonl --court colo --page_size 100
+```
+
+Provide an API key with `--api_key` if your requests require authentication.
+
+## Extracting IPs from Logs
+The `parse_log.py` script finds all IPv4 addresses in a log file:
+
+```bash
+python scripts/parse_log.py path/to/logfile.log
+```
+
+This can help identify network activity related to your case documents.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pdfplumber
+transformers
+datasets
+langchain
+faiss-cpu
+requests

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -1,0 +1,39 @@
+import os
+import json
+from pathlib import Path
+from typing import List, Dict
+
+import pdfplumber
+
+
+def extract_text_from_pdf(pdf_path: Path) -> str:
+    """Extracts text from a single PDF file."""
+    with pdfplumber.open(pdf_path) as pdf:
+        pages = [page.extract_text() or "" for page in pdf.pages]
+    return "\n".join(pages)
+
+
+def build_dataset(input_dir: str, output_file: str) -> None:
+    """Walk through input_dir and save extracted text to a JSONL dataset."""
+    records: List[Dict[str, str]] = []
+    for root, _, files in os.walk(input_dir):
+        for fname in files:
+            if fname.lower().endswith('.pdf'):
+                pdf_path = Path(root) / fname
+                text = extract_text_from_pdf(pdf_path)
+                records.append({"file": str(pdf_path), "text": text})
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build a JSONL dataset from PDFs")
+    parser.add_argument("input_dir", help="Directory containing PDFs")
+    parser.add_argument("output_file", help="Path to output JSONL file")
+    args = parser.parse_args()
+
+    build_dataset(args.input_dir, args.output_file)

--- a/scripts/fetch_caselaw.py
+++ b/scripts/fetch_caselaw.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List, Dict, Optional
+
+import requests
+
+
+API_ROOT = "https://www.courtlistener.com/api/rest/v3"
+
+
+def fetch_opinions(court: str = "colo", page_size: int = 100, api_key: Optional[str] = None) -> List[Dict]:
+    """Fetch opinions from CourtListener API for a given court."""
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Token {api_key}"
+
+    url = f"{API_ROOT}/opinions/?court={court}&page_size={page_size}"
+    opinions: List[Dict] = []
+
+    while url:
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        opinions.extend(data.get("results", []))
+        url = data.get("next")
+    return opinions
+
+
+def save_opinions(opinions: List[Dict], output_file: Path) -> None:
+    with output_file.open("w", encoding="utf-8") as f:
+        for op in opinions:
+            f.write(json.dumps(op, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fetch Colorado caselaw from CourtListener")
+    parser.add_argument("output_file", type=Path, help="Path to write opinions JSONL")
+    parser.add_argument("--court", default="colo", help="Court slug (default: colorado)")
+    parser.add_argument("--page_size", type=int, default=100, help="Number of results per page")
+    parser.add_argument("--api_key", help="Optional CourtListener API key")
+    args = parser.parse_args()
+
+    ops = fetch_opinions(args.court, args.page_size, args.api_key)
+    save_opinions(ops, args.output_file)

--- a/scripts/parse_log.py
+++ b/scripts/parse_log.py
@@ -1,0 +1,27 @@
+import re
+from pathlib import Path
+from typing import List
+
+
+def extract_ips(log_text: str) -> List[str]:
+    """Extract all IPv4 addresses from the given log text."""
+    ip_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    return re.findall(ip_pattern, log_text)
+
+
+def parse_log_file(path: Path) -> List[str]:
+    """Read a log file and return all IP addresses found."""
+    text = path.read_text(errors="ignore")
+    return extract_ips(text)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract IP addresses from a log file")
+    parser.add_argument("logfile", type=Path)
+    args = parser.parse_args()
+
+    ips = parse_log_file(args.logfile)
+    for ip in ips:
+        print(ip)

--- a/scripts/setup_rag.py
+++ b/scripts/setup_rag.py
@@ -1,0 +1,29 @@
+"""Simple example of setting up a retrieval-augmented generation (RAG) pipeline."""
+import argparse
+from pathlib import Path
+
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.document_loaders import JSONLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+
+def build_vector_store(dataset_path: str, persist_dir: str = "faiss_index") -> None:
+    loader = JSONLoader(dataset_path, jq_schema=".text")
+    docs = loader.load()
+
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    docs = splitter.split_documents(docs)
+
+    embeddings = HuggingFaceEmbeddings()
+    db = FAISS.from_documents(docs, embeddings)
+    db.save_local(persist_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build FAISS index from dataset")
+    parser.add_argument("dataset_path", help="Path to JSONL dataset")
+    parser.add_argument("--persist_dir", default="faiss_index")
+    args = parser.parse_args()
+
+    build_vector_store(args.dataset_path, args.persist_dir)

--- a/scripts/train_llm.py
+++ b/scripts/train_llm.py
@@ -1,0 +1,43 @@
+"""Example fine-tuning script for a 7B model on your dataset."""
+import argparse
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, TrainingArguments, Trainer
+
+
+def main(dataset_path: str, model_name: str = "mistralai/Mistral-7B-v0.1", output_dir: str = "model_out"):
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+
+    dataset = load_dataset("json", data_files=dataset_path, split="train")
+
+    def tokenize_fn(example):
+        return tokenizer(example["text"], truncation=True, max_length=1024)
+
+    tokenized = dataset.map(tokenize_fn, batched=True, remove_columns=["file", "text"])
+
+    args = TrainingArguments(
+        output_dir=output_dir,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=8,
+        num_train_epochs=1,
+        fp16=True,
+        logging_steps=10,
+        save_steps=500,
+    )
+
+    trainer = Trainer(model=model, args=args, train_dataset=tokenized)
+    trainer.train()
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fine-tune a 7B model on your dataset")
+    parser.add_argument("dataset_path", help="Path to JSONL dataset created by build_dataset.py")
+    parser.add_argument("--model_name", default="mistralai/Mistral-7B-v0.1")
+    parser.add_argument("--output_dir", default="model_out")
+    args = parser.parse_args()
+
+    main(args.dataset_path, args.model_name, args.output_dir)


### PR DESCRIPTION
## Summary
- include `fetch_caselaw.py` for downloading Colorado opinions from CourtListener
- add `parse_log.py` with a simple IP extraction function
- document new scripts in README
- add `requests` to requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aceb05fe08320a65e820ee56a1dbc